### PR TITLE
Bump to 3.34.0

### DIFF
--- a/org.gnome.LightsOff.json
+++ b/org.gnome.LightsOff.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.LightsOff",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.32",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "lightsoff",
     "finish-args": [
@@ -9,10 +9,7 @@
         "--share=ipc", "--socket=x11",
         /* Wayland access */
         "--socket=wayland",
-        "--device=dri",
-        /* dconf */
-        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--device=dri"
     ],
     "modules": [
         {
@@ -21,8 +18,8 @@
             "sources": [{
                 "type": "git",
                 "url": "https://gitlab.gnome.org/GNOME/lightsoff.git",
-                "tag": "3.32.0",
-                "commit": "6f05d33a890c3026e2e13720f107daae54f6e505"
+                "tag": "3.34.0",
+                "commit": "146d937a11f7188d5fcb71fb8f50c871a5a7b359"
             }]
         }
     ]


### PR DESCRIPTION
This also removes dconf access as it's not needed anymore